### PR TITLE
added config adjustments

### DIFF
--- a/helm/fluentd-elasticsearch/templates/configmap.yaml
+++ b/helm/fluentd-elasticsearch/templates/configmap.yaml
@@ -14,3 +14,41 @@ data:
   {{ $key }}: |-
 {{ $value | indent 4 }}
 {{- end }}
+
+  output.conf: |-
+    <match **>
+      @id elasticsearch
+      @type elasticsearch
+      @log_level info
+      include_tag_key true
+      type_name _doc
+      host "#{ENV['OUTPUT_HOST']}"
+      port "#{ENV['OUTPUT_PORT']}"
+      scheme "#{ENV['OUTPUT_SCHEME']}"
+      ssl_version "#{ENV['OUTPUT_SSL_VERSION']}"
+      ssl_verify true
+      user "#{ENV['OUTPUT_USER']}"
+      password "#{ENV['OUTPUT_PASSWORD']}"
+      logstash_format true
+      logstash_prefix "#{ENV['LOGSTASH_PREFIX']}"
+      reconnect_on_error true
+      reload_on_failure true
+      reload_connections true
+      template_name {{ .Values.configuration.template.name }}
+      template_file {{ .Values.configuration.template.filepath }}{{ .Values.configuration.template.filename }}
+      template_overwrite {{ .Values.configuration.template.overwrite }}
+      log_es_400_reason true
+      <buffer>
+        @type file
+        path /var/log/fluentd-buffers/kubernetes.system.buffer
+        flush_mode interval
+        retry_type exponential_backoff
+        flush_thread_count 2
+        flush_interval 5s
+        retry_forever
+        retry_max_interval 30
+        chunk_limit_size "#{ENV['OUTPUT_BUFFER_CHUNK_LIMIT']}"
+        queue_limit_length "#{ENV['OUTPUT_BUFFER_QUEUE_LIMIT']}"
+        overflow_action block
+      </buffer>
+    </match>

--- a/helm/fluentd-elasticsearch/templates/configmap_template.yaml
+++ b/helm/fluentd-elasticsearch/templates/configmap_template.yaml
@@ -11,4 +11,4 @@ metadata:
     addonmanager.kubernetes.io/mode: Reconcile
 data:
   {{ .Values.configuration.template.filename }}: |-
-{{ toJson .Values.configuration.template.content | indent 4 }}
+{{ .Values.configuration.template.content | indent 4 }}

--- a/helm/fluentd-elasticsearch/templates/configmap_template.yaml
+++ b/helm/fluentd-elasticsearch/templates/configmap_template.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: elasticsearch-template
+  labels:
+    app.kubernetes.io/name: {{ include "fluentd-elasticsearch.name" . }}
+    helm.sh/chart: {{ include "fluentd-elasticsearch.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+data:
+  {{ .Values.configuration.template.filename }}: |-
+{{ toJson .Values.configuration.template.content | indent 4 }}

--- a/helm/fluentd-elasticsearch/templates/daemonset.yaml
+++ b/helm/fluentd-elasticsearch/templates/daemonset.yaml
@@ -107,6 +107,8 @@ spec:
         - name: libsystemddir
           mountPath: /host/lib
           readOnly: true
+        - name: config-es
+          mountPath: {{ .Values.configuration.template.filepath }}{{ .Values.configuration.template.filename }}
         - name: config-volume
           mountPath: /etc/fluent/config.d
 {{- if .Values.extraVolumeMounts }}
@@ -166,6 +168,9 @@ spec:
       - name: libsystemddir
         hostPath:
           path: /usr/lib64
+      - name: config-es
+        configMap:
+          name: {{ include "fluentd-elasticsearch.fullname" . }}"-template"
       - name: config-volume
         configMap:
           name: {{ include "fluentd-elasticsearch.fullname" . }}

--- a/helm/fluentd-elasticsearch/templates/daemonset.yaml
+++ b/helm/fluentd-elasticsearch/templates/daemonset.yaml
@@ -108,7 +108,7 @@ spec:
           mountPath: /host/lib
           readOnly: true
         - name: config-es
-          mountPath: {{ .Values.configuration.template.filepath }}{{ .Values.configuration.template.filename }}
+          mountPath: {{ .Values.configuration.template.filepath }}
         - name: config-volume
           mountPath: /etc/fluent/config.d
 {{- if .Values.extraVolumeMounts }}

--- a/helm/fluentd-elasticsearch/templates/daemonset.yaml
+++ b/helm/fluentd-elasticsearch/templates/daemonset.yaml
@@ -170,7 +170,7 @@ spec:
           path: /usr/lib64
       - name: config-es
         configMap:
-          name: {{ include "fluentd-elasticsearch.fullname" . }}"-template"
+          name: elasticsearch-template
       - name: config-volume
         configMap:
           name: {{ include "fluentd-elasticsearch.fullname" . }}

--- a/helm/fluentd-elasticsearch/values.yaml
+++ b/helm/fluentd-elasticsearch/values.yaml
@@ -139,17 +139,7 @@ configuration:
     filename: "es_mapping.json"
     filepath: "/fluentd/etc/"
     overwrite: true
-    content: |-
-      {
-        "template": "logging",
-        "mappings": {
-          "_default_": {
-            "dynamic_templates": [],
-            "properties" : {
-            }
-          }
-        }
-      }
+    content: '{"template":"logging","mappings":{"_default_":{"dynamic_templates":[],"properties":{}}}}'
 
 configMaps:
   system.conf: |-

--- a/helm/fluentd-elasticsearch/values.yaml
+++ b/helm/fluentd-elasticsearch/values.yaml
@@ -36,7 +36,7 @@ elasticsearch:
   ssl_version: TLSv1_2
   user: ""
   password: ""
-  buffer_chunk_limit: 2M
+  buffer_chunk_limit: 4M
   buffer_queue_limit: 8
   logstash_prefix: 'logstash'
 
@@ -301,235 +301,6 @@ configMaps:
       </parse>
     </filter>
 
-  system.input.conf: |-
-    # Example:
-    # 2015-12-21 23:17:22,066 [salt.state       ][INFO    ] Completed state [net.ipv4.ip_forward] at time 23:17:22.066081
-    <source>
-      @id minion
-      @type tail
-      format /^(?<time>[^ ]* [^ ,]*)[^\[]*\[[^\]]*\]\[(?<severity>[^ \]]*) *\] (?<message>.*)$/
-      time_format %Y-%m-%d %H:%M:%S
-      path /var/log/salt/minion
-      pos_file /var/log/salt.pos
-      tag salt
-    </source>
-
-    # Example:
-    # Dec 21 23:17:22 gke-foo-1-1-4b5cbd14-node-4eoj startupscript: Finished running startup script /var/run/google.startup.script
-    <source>
-      @id startupscript.log
-      @type tail
-      format syslog
-      path /var/log/startupscript.log
-      pos_file /var/log/startupscript.log.pos
-      tag startupscript
-    </source>
-
-    # Examples:
-    # time="2016-02-04T06:51:03.053580605Z" level=info msg="GET /containers/json"
-    # time="2016-02-04T07:53:57.505612354Z" level=error msg="HTTP Error" err="No such image: -f" statusCode=404
-    # TODO(random-liu): Remove this after cri container runtime rolls out.
-    <source>
-      @id docker.log
-      @type tail
-      format /^time="(?<time>[^)]*)" level=(?<severity>[^ ]*) msg="(?<message>[^"]*)"( err="(?<error>[^"]*)")?( statusCode=($<status_code>\d+))?/
-      path /var/log/docker.log
-      pos_file /var/log/docker.log.pos
-      tag docker
-    </source>
-
-    # Example:
-    # 2016/02/04 06:52:38 filePurge: successfully removed file /var/etcd/data/member/wal/00000000000006d0-00000000010a23d1.wal
-    <source>
-      @id etcd.log
-      @type tail
-      # Not parsing this, because it doesn't have anything particularly useful to
-      # parse out of it (like severities).
-      format none
-      path /var/log/etcd.log
-      pos_file /var/log/etcd.log.pos
-      tag etcd
-    </source>
-
-    # Multi-line parsing is required for all the kube logs because very large log
-    # statements, such as those that include entire object bodies, get split into
-    # multiple lines by glog.
-    # Example:
-    # I0204 07:32:30.020537    3368 server.go:1048] POST /stats/container/: (13.972191ms) 200 [[Go-http-client/1.1] 10.244.1.3:40537]
-    <source>
-      @id kubelet.log
-      @type tail
-      format multiline
-      multiline_flush_interval 5s
-      format_firstline /^\w\d{4}/
-      format1 /^(?<severity>\w)(?<time>\d{4} [^\s]*)\s+(?<pid>\d+)\s+(?<source>[^ \]]+)\] (?<message>.*)/
-      time_format %m%d %H:%M:%S.%N
-      path /var/log/kubelet.log
-      pos_file /var/log/kubelet.log.pos
-      tag kubelet
-    </source>
-
-    # Example:
-    # I1118 21:26:53.975789       6 proxier.go:1096] Port "nodePort for kube-system/default-http-backend:http" (:31429/tcp) was open before and is still needed
-    <source>
-      @id kube-proxy.log
-      @type tail
-      format multiline
-      multiline_flush_interval 5s
-      format_firstline /^\w\d{4}/
-      format1 /^(?<severity>\w)(?<time>\d{4} [^\s]*)\s+(?<pid>\d+)\s+(?<source>[^ \]]+)\] (?<message>.*)/
-      time_format %m%d %H:%M:%S.%N
-      path /var/log/kube-proxy.log
-      pos_file /var/log/kube-proxy.log.pos
-      tag kube-proxy
-    </source>
-
-    # Example:
-    # I0204 07:00:19.604280       5 handlers.go:131] GET /api/v1/nodes: (1.624207ms) 200 [[kube-controller-manager/v1.1.3 (linux/amd64) kubernetes/6a81b50] 127.0.0.1:38266]
-    <source>
-      @id kube-apiserver.log
-      @type tail
-      format multiline
-      multiline_flush_interval 5s
-      format_firstline /^\w\d{4}/
-      format1 /^(?<severity>\w)(?<time>\d{4} [^\s]*)\s+(?<pid>\d+)\s+(?<source>[^ \]]+)\] (?<message>.*)/
-      time_format %m%d %H:%M:%S.%N
-      path /var/log/kube-apiserver.log
-      pos_file /var/log/kube-apiserver.log.pos
-      tag kube-apiserver
-    </source>
-
-    # Example:
-    # I0204 06:55:31.872680       5 servicecontroller.go:277] LB already exists and doesn't need update for service kube-system/kube-ui
-    <source>
-      @id kube-controller-manager.log
-      @type tail
-      format multiline
-      multiline_flush_interval 5s
-      format_firstline /^\w\d{4}/
-      format1 /^(?<severity>\w)(?<time>\d{4} [^\s]*)\s+(?<pid>\d+)\s+(?<source>[^ \]]+)\] (?<message>.*)/
-      time_format %m%d %H:%M:%S.%N
-      path /var/log/kube-controller-manager.log
-      pos_file /var/log/kube-controller-manager.log.pos
-      tag kube-controller-manager
-    </source>
-
-    # Example:
-    # W0204 06:49:18.239674       7 reflector.go:245] pkg/scheduler/factory/factory.go:193: watch of *api.Service ended with: 401: The event in requested index is outdated and cleared (the requested history has been cleared [2578313/2577886]) [2579312]
-    <source>
-      @id kube-scheduler.log
-      @type tail
-      format multiline
-      multiline_flush_interval 5s
-      format_firstline /^\w\d{4}/
-      format1 /^(?<severity>\w)(?<time>\d{4} [^\s]*)\s+(?<pid>\d+)\s+(?<source>[^ \]]+)\] (?<message>.*)/
-      time_format %m%d %H:%M:%S.%N
-      path /var/log/kube-scheduler.log
-      pos_file /var/log/kube-scheduler.log.pos
-      tag kube-scheduler
-    </source>
-
-    # Example:
-    # I0603 15:31:05.793605       6 cluster_manager.go:230] Reading config from path /etc/gce.conf
-    <source>
-      @id glbc.log
-      @type tail
-      format multiline
-      multiline_flush_interval 5s
-      format_firstline /^\w\d{4}/
-      format1 /^(?<severity>\w)(?<time>\d{4} [^\s]*)\s+(?<pid>\d+)\s+(?<source>[^ \]]+)\] (?<message>.*)/
-      time_format %m%d %H:%M:%S.%N
-      path /var/log/glbc.log
-      pos_file /var/log/glbc.log.pos
-      tag glbc
-    </source>
-
-    # Example:
-    # TODO Add a proper example here.
-    <source>
-      @id cluster-autoscaler.log
-      @type tail
-      format multiline
-      multiline_flush_interval 5s
-      format_firstline /^\w\d{4}/
-      format1 /^(?<severity>\w)(?<time>\d{4} [^\s]*)\s+(?<pid>\d+)\s+(?<source>[^ \]]+)\] (?<message>.*)/
-      time_format %m%d %H:%M:%S.%N
-      path /var/log/cluster-autoscaler.log
-      pos_file /var/log/cluster-autoscaler.log.pos
-      tag cluster-autoscaler
-    </source>
-
-    # Logs from systemd-journal for interesting services.
-    # TODO(random-liu): Remove this after cri container runtime rolls out.
-    <source>
-      @id journald-docker
-      @type systemd
-      matches [{ "_SYSTEMD_UNIT": "docker.service" }]
-      <storage>
-        @type local
-        persistent true
-        path /var/log/journald-docker.pos
-      </storage>
-      read_from_head true
-      tag docker
-    </source>
-
-    <source>
-      @id journald-container-runtime
-      @type systemd
-      matches [{ "_SYSTEMD_UNIT": "{{ fluentd_container_runtime_service }}.service" }]
-      <storage>
-        @type local
-        persistent true
-        path /var/log/journald-container-runtime.pos
-      </storage>
-      read_from_head true
-      tag container-runtime
-    </source>
-
-    <source>
-      @id journald-kubelet
-      @type systemd
-      matches [{ "_SYSTEMD_UNIT": "kubelet.service" }]
-      <storage>
-        @type local
-        persistent true
-        path /var/log/journald-kubelet.pos
-      </storage>
-      read_from_head true
-      tag kubelet
-    </source>
-
-    <source>
-      @id journald-node-problem-detector
-      @type systemd
-      matches [{ "_SYSTEMD_UNIT": "node-problem-detector.service" }]
-      <storage>
-        @type local
-        persistent true
-        path /var/log/journald-node-problem-detector.pos
-      </storage>
-      read_from_head true
-      tag node-problem-detector
-    </source>
-
-    <source>
-      @id kernel
-      @type systemd
-      matches [{ "_TRANSPORT": "kernel" }]
-      <storage>
-        @type local
-        persistent true
-        path /var/log/kernel.pos
-      </storage>
-      <entry>
-        fields_strip_underscores true
-        fields_lowercase true
-      </entry>
-      read_from_head true
-      tag kernel
-    </source>
-
   forward.input.conf: |-
     # Takes the messages sent over TCP
     <source>
@@ -594,6 +365,12 @@ configMaps:
       logstash_format true
       logstash_prefix "#{ENV['LOGSTASH_PREFIX']}"
       reconnect_on_error true
+      reload_on_failure true
+      reload_connections true
+      log_es_400_reason true
+      template_name "svh_logging"
+      template_file "/fluentd/etc/es_mapping.json"
+      template_overwrite true
       <buffer>
         @type file
         path /var/log/fluentd-buffers/kubernetes.system.buffer

--- a/helm/fluentd-elasticsearch/values.yaml
+++ b/helm/fluentd-elasticsearch/values.yaml
@@ -132,6 +132,25 @@ prometheusRule:
   labels: {}
   #  role: alert-rules
 
+
+configuration:
+  template:
+    name: "logging"
+    filename: "es_mapping.json"
+    filepath: "/fluentd/etc/"
+    overwrite: true
+    content: |-
+      {
+        "template": "logging",
+        "mappings": {
+          "_default_": {
+            "dynamic_templates": [],
+            "properties" : {
+            }
+          }
+        }
+      }
+
 configMaps:
   system.conf: |-
     <system>
@@ -347,41 +366,6 @@ configMaps:
         host ${hostname}
       </labels>
     </source>
-
-  output.conf: |-
-    <match **>
-      @id elasticsearch
-      @type elasticsearch
-      @log_level info
-      include_tag_key true
-      type_name _doc
-      host "#{ENV['OUTPUT_HOST']}"
-      port "#{ENV['OUTPUT_PORT']}"
-      scheme "#{ENV['OUTPUT_SCHEME']}"
-      ssl_version "#{ENV['OUTPUT_SSL_VERSION']}"
-      ssl_verify true
-      user "#{ENV['OUTPUT_USER']}"
-      password "#{ENV['OUTPUT_PASSWORD']}"
-      logstash_format true
-      logstash_prefix "#{ENV['LOGSTASH_PREFIX']}"
-      reconnect_on_error true
-      reload_on_failure true
-      reload_connections true
-      log_es_400_reason true
-      <buffer>
-        @type file
-        path /var/log/fluentd-buffers/kubernetes.system.buffer
-        flush_mode interval
-        retry_type exponential_backoff
-        flush_thread_count 2
-        flush_interval 5s
-        retry_forever
-        retry_max_interval 30
-        chunk_limit_size "#{ENV['OUTPUT_BUFFER_CHUNK_LIMIT']}"
-        queue_limit_length "#{ENV['OUTPUT_BUFFER_QUEUE_LIMIT']}"
-        overflow_action block
-      </buffer>
-    </match>
 
 
 # extraVolumes:

--- a/helm/fluentd-elasticsearch/values.yaml
+++ b/helm/fluentd-elasticsearch/values.yaml
@@ -368,9 +368,6 @@ configMaps:
       reload_on_failure true
       reload_connections true
       log_es_400_reason true
-      template_name "svh_logging"
-      template_file "/fluentd/etc/es_mapping.json"
-      template_overwrite true
       <buffer>
         @type file
         path /var/log/fluentd-buffers/kubernetes.system.buffer


### PR DESCRIPTION
Changes required from Telekom to facilitate their preferred setup of the fluentd based on their experience:

- buffer_chunk_limit - to 4M based on experienced load
- exclude system.input.conf - this is too much on the nodes based on experience
- output.conf - enable log_es_400_reason
- output.conf - enable reload_connections
- output.conf - enable reload_on_failure
- output.conf -  provide solution so that the template can be specified for the mapping:
      template_name "svh_logging"
      template_file "/fluentd/etc/es_mapping.json"
      template_overwrite true
   (not sure how to continue with that point or if that is correct to do)
