### PR TITLE
helm: escape [[ in templating

### DIFF
--- a/helm/fluentd-elasticsearch/templates/configmaps.yaml
+++ b/helm/fluentd-elasticsearch/templates/configmaps.yaml
@@ -205,7 +205,7 @@ data:
     <source>
       @id minion
       @type tail
-      format /^(?<time>[^ ]* [^ ,]*)[^\[]*\[[^\]]*\]\[(?<severity>[^ \]]*) *\] (?<message>.*)$/
+      format [[ `/^(?<time>[^ ]* [^ ,]*)[^\[]*\[[^\]]*\]\[(?<severity>[^ \]]*) *\] (?<message>.*)$/` ]] 
       time_format %Y-%m-%d %H:%M:%S
       path /var/log/salt/minion
       pos_file /var/log/salt.pos
@@ -253,7 +253,7 @@ data:
     # statements, such as those that include entire object bodies, get split into
     # multiple lines by glog.
     # Example:
-    # I0204 07:32:30.020537    3368 server.go:1048] POST /stats/container/: (13.972191ms) 200 [[Go-http-client/1.1] 10.244.1.3:40537]
+    # [[ `I0204 07:32:30.020537    3368 server.go:1048] POST /stats/container/: (13.972191ms) 200 [[Go-http-client/1.1] 10.244.1.3:40537]` ]]
     <source>
       @id kubelet.log
       @type tail
@@ -283,7 +283,7 @@ data:
     </source>
 
     # Example:
-    # I0204 07:00:19.604280       5 handlers.go:131] GET /api/v1/nodes: (1.624207ms) 200 [[kube-controller-manager/v1.1.3 (linux/amd64) kubernetes/6a81b50] 127.0.0.1:38266]
+    # [[ `I0204 07:00:19.604280       5 handlers.go:131] GET /api/v1/nodes: (1.624207ms) 200 [[kube-controller-manager/v1.1.3 (linux/amd64) kubernetes/6a81b50] 127.0.0.1:38266]` ]]
     <source>
       @id kube-apiserver.log
       @type tail


### PR DESCRIPTION
Fixes https://github.com/giantswarm/giantswarm/issues/7271.

`architect helm template` templates using `[[` & `]]` delimiters. So all
`[[.*]]` sequences need to be escaped. A way to do that is to wrap them
with ```[[ `[[.*]]` ]]```.

Related SO thread: https://stackoverflow.com/questions/17641887/how-do-i-escape-and-delimiters-in-go-templates.

Diff after running `architect helm template`:

```diff
$ git --no-pager diff --no-color
diff --git a/helm/fluentd-elasticsearch/Chart.yaml b/helm/fluentd-elasticsearch/Chart.yaml
index a8cb3e1..a9de7b6 100644
--- a/helm/fluentd-elasticsearch/Chart.yaml
+++ b/helm/fluentd-elasticsearch/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: 2.7.0
 description: A Helm chart for fluentd-elasticsearch -- testing
 name: fluentd-elasticsearch
-version: [[ .Version ]]
+version: 0.2.2-b18a367add4f75009bd849ad496aee59053a182a
diff --git a/helm/fluentd-elasticsearch/templates/configmaps.yaml b/helm/fluentd-elasticsearch/templates/configmaps.yaml
index 82217c7..771cc44 100644
--- a/helm/fluentd-elasticsearch/templates/configmaps.yaml
+++ b/helm/fluentd-elasticsearch/templates/configmaps.yaml
@@ -205,7 +205,7 @@ data:
     <source>
       @id minion
       @type tail
-      format [[ `/^(?<time>[^ ]* [^ ,]*)[^\[]*\[[^\]]*\]\[(?<severity>[^ \]]*) *\] (?<message>.*)$/` ]]
+      format /^(?<time>[^ ]* [^ ,]*)[^\[]*\[[^\]]*\]\[(?<severity>[^ \]]*) *\] (?<message>.*)$/
       time_format %Y-%m-%d %H:%M:%S
       path /var/log/salt/minion
       pos_file /var/log/salt.pos
@@ -253,7 +253,7 @@ data:
     # statements, such as those that include entire object bodies, get split into
     # multiple lines by glog.
     # Example:
-    # [[ `I0204 07:32:30.020537    3368 server.go:1048] POST /stats/container/: (13.972191ms) 200 [[Go-http-client/1.1] 10.244.1.3:40537]` ]]
+    # I0204 07:32:30.020537    3368 server.go:1048] POST /stats/container/: (13.972191ms) 200 [[Go-http-client/1.1] 10.244.1.3:40537]
     <source>
       @id kubelet.log
       @type tail
@@ -283,7 +283,7 @@ data:
     </source>

     # Example:
-    # [[ `I0204 07:00:19.604280       5 handlers.go:131] GET /api/v1/nodes: (1.624207ms) 200 [[kube-controller-manager/v1.1.3 (linux/amd64) kubernetes/6a81b50] 127.0.0.1:38266]` ]]
+    # I0204 07:00:19.604280       5 handlers.go:131] GET /api/v1/nodes: (1.624207ms) 200 [[kube-controller-manager/v1.1.3 (linux/amd64) kubernetes/6a81b50] 127.0.0.1:38266]
     <source>
       @id kube-apiserver.log
       @type tail
```